### PR TITLE
checking for options when logging before getting one

### DIFF
--- a/local-storage.js
+++ b/local-storage.js
@@ -704,7 +704,7 @@ LocalStorage.prototype = {
     },
 
     log: function () {
-        this.options.logging && console.log.apply(console, arguments);
+        this.options && this.options.logging && console.log.apply(console, arguments);
     }
 };
 


### PR DESCRIPTION
During `setOptions`: `resolveDir` calls `log` after building the directory path. If `options.logging` is not defined, the module will break here.